### PR TITLE
Integrate Itemcolourstrings

### DIFF
--- a/blrecipe/clt/itemcolorstrings.py
+++ b/blrecipe/clt/itemcolorstrings.py
@@ -1,0 +1,180 @@
+"""
+Read and interpret the Boundless itemcolorstrings.dat file
+"""
+
+from collections import namedtuple
+from struct import unpack_from
+
+
+VarLen = namedtuple('VarLen', ['data_offset', 'data_len'])
+
+VAR_LEN = [VarLen(1, 3), VarLen(2, 6), VarLen(1, 3), VarLen(2, 10)]
+
+
+class StringTable(object):
+    """
+    A decoded string table.
+    """
+
+    def __init__(self, data, offset, max_index):
+        self._data = data
+        self._names = []
+
+        (encodings_offset, word_index_offset, words_offset, bit_length) = unpack_from('<IIIB', self._data, offset)
+        offset += (3 * 4 + 1)
+        encoding_indeces = [self._decode_intsize(offset, bit_length, i)
+                            for i in range(max_index)]
+
+        word_index_bit_length = unpack_from('<B', self._data, word_index_offset)[0]
+        word_index_length = int((words_offset - word_index_offset) * 8 / word_index_bit_length)
+        word_indeces = [self._decode_intsize(word_index_offset+1, word_index_bit_length, i)
+                        for i in range(word_index_length+1)]
+
+        for i in range(max_index):
+            self._names.append('')
+            encoding_offset = encodings_offset + encoding_indeces[i]
+            bit_offset = 0
+            encoding = self._decode_varlen(encoding_offset, bit_offset)
+            word_count = self._get_bits_at(encoding_offset,
+                                           bit_offset + encoding.data_offset,
+                                           encoding.data_len)
+            for w in range(word_count):
+                bit_offset += (encoding.data_offset + encoding.data_len)
+                encoding = self._decode_varlen(encoding_offset, bit_offset)
+                word_index = self._get_bits_at(encoding_offset,
+                                               bit_offset + encoding.data_offset,
+                                               encoding.data_len)
+                fmt = '{}s'.format(word_indeces[word_index+1] - word_indeces[word_index])
+                off = words_offset + word_indeces[word_index]
+                word = unpack_from(fmt, self._data, off)[0].decode('iso8859-1')
+                sep = (' ' if w > 0 else '')
+                self._names[i] = sep.join((self._names[i], word))
+
+    def _decode_intsize(self, base_offset, bit_length, index):
+        """
+        Extracts the bit_length-bit integer stored at index index from base_offset.
+        """
+        byte_offset = base_offset + int(index * bit_length / 8)
+        bit_offset = (index * bit_length) % 8
+        (word,) = unpack_from("<I", self._data, byte_offset)
+        value = int(format(word, '032b')[::-1][bit_offset:bit_offset+bit_length][::-1], 2)
+        return value
+
+    def _get_bits_at(self, base_offset, bit_offset, bit_len):
+        """
+        Get the bit_len bits at bit_offset bits from base_offset as an integer.
+        """
+        byte_offset = int(bit_offset / 8)
+        bit_in_byte_offset = bit_offset % 8
+        (word,) = unpack_from("<I", self._data, base_offset + byte_offset)
+        value = int(format(word, '032b')[::-1][bit_in_byte_offset:bit_in_byte_offset+bit_len][::-1], 2)
+        return value
+
+    def _decode_varlen(self, base_offset, bit_offset):
+        return VAR_LEN[self._get_bits_at(base_offset, bit_offset, 2)]
+
+    def name(self, index):
+        """
+        Get an indicated name.
+        """
+        return self._names[index]
+
+
+class Translation(object):
+    """
+    A set of localized names for things.
+    """
+
+    def __init__(self, data, offset, name_counts):
+        (colour_string_offset, metal_string_offset, item_string_offset) = unpack_from('<III', data, offset)
+        offset += (3 * 4)
+        self._si = StringTable(data, offset, name_counts["subtitles"]+1)
+        self._ci = StringTable(data, colour_string_offset, name_counts["colours"])
+        self._mi = StringTable(data, metal_string_offset, name_counts["metals"])
+        self._ii = StringTable(data, item_string_offset, name_counts["items"])
+
+    def subtitle(self, index):
+        """
+        Get an indicated subtitle
+        """
+        return self._si.name(index)
+
+    def colour(self, index):
+        """
+        Get an indicated colour name
+        """
+        return self._ci.name(index)
+
+    def metal(self, index):
+        """
+        Get an indicated metal name
+        """
+        return self._mi.name(index)
+
+    def item(self, index):
+        """
+        Get an indicated item name
+        """
+        return self._ii.name(index)
+
+
+class ObjectNames(object):
+    """
+    A collection of localized object names
+    """
+
+    def __init__(self, filename):
+        self._name_counts = {
+            "colours": 255,
+            "items": 0,
+            "languages": 0,
+            "metals": 0,
+            "subtitles": 0,
+        }
+        self._items = []
+        self._languages = {}
+
+        with open(filename, 'rb') as datfile:
+            self._data = datfile.read()
+
+            offset = 0
+
+            self._name_counts["metals"] = unpack_from('<B', self._data, offset)[0]
+            offset += 1
+
+            self._name_counts["items"] = unpack_from('<H', self._data, offset)[0]
+            offset += 2
+
+            for _ in range(self._name_counts["items"]):
+                (item_id, item_subindex) = unpack_from('<HB', self._data, offset)
+                offset += (1 + 2)
+                if item_subindex > self._name_counts["subtitles"]:
+                    self._name_counts["subtitles"] = item_subindex
+                self._items.append((item_id, item_subindex))
+
+            self._name_counts["languages"] = unpack_from('<B', self._data, offset)[0]
+            offset += 1
+
+            for _ in range(self._name_counts["languages"]):
+                (name_length,) = unpack_from('<B', self._data, offset)
+                offset += 1
+                (name, language_offset) = unpack_from('<{}sI'.format(name_length), self._data, offset)
+                offset += (name_length + 4)
+                self._languages[name.decode('iso8859-1')] = language_offset
+
+    def translation(self, language):
+        """
+        Get the translation for a named language
+        """
+        return Translation(self._data, self._languages[language], self._name_counts)
+
+    def item_count(self):
+        return self._name_counts["items"]
+
+    def item(self, index):
+        return self._items[index]
+
+    def languages(self):
+        return self._languages
+
+

--- a/blrecipe/clt/itemcolorstrings.py
+++ b/blrecipe/clt/itemcolorstrings.py
@@ -38,7 +38,7 @@ class StringTable(object):
             word_count = self._get_bits_at(encoding_offset,
                                            bit_offset + encoding.data_offset,
                                            encoding.data_len)
-            for w in range(word_count):
+            for word_index in range(word_count):
                 bit_offset += (encoding.data_offset + encoding.data_len)
                 encoding = self._decode_varlen(encoding_offset, bit_offset)
                 word_index = self._get_bits_at(encoding_offset,
@@ -47,7 +47,7 @@ class StringTable(object):
                 fmt = '{}s'.format(word_indeces[word_index+1] - word_indeces[word_index])
                 off = words_offset + word_indeces[word_index]
                 word = unpack_from(fmt, self._data, off)[0].decode('iso8859-1')
-                sep = (' ' if w > 0 else '')
+                sep = (' ' if word_index > 0 else '')
                 self._names[i] = sep.join((self._names[i], word))
 
     def _decode_intsize(self, base_offset, bit_length, index):
@@ -169,15 +169,27 @@ class ObjectNames(object):
         return Translation(self._data, self._languages[language], self._name_counts)
 
     def item_count(self):
+        """
+        Get the number of items with translations
+        """
         return self._name_counts["items"]
 
     def item(self, index):
+        """
+        Get an indicated (item_id, subtitle_id) pair
+        """
         return self._items[index]
 
     def languages(self):
+        """
+        Get the number of languages with translations
+        """
         return self._languages
 
     def metal_count(self):
+        """
+        Get the number of metal names with translations
+        """
         return self._name_counts["metals"]
 
 

--- a/blrecipe/clt/itemcolorstrings.py
+++ b/blrecipe/clt/itemcolorstrings.py
@@ -177,4 +177,7 @@ class ObjectNames(object):
     def languages(self):
         return self._languages
 
+    def metal_count(self):
+        return self._name_counts["metals"]
+
 

--- a/blrecipe/clt/load.py
+++ b/blrecipe/clt/load.py
@@ -248,8 +248,7 @@ class Loader(object):  # pylint: disable=too-few-public-methods
         for key, item in itemlist.items():
             if self._args.verbose:
                 print('adding item"{}"'.format(item['name']))
-            itemrec = Item(id=key,
-                           name=item['name'],
+            itemrec = Item(id=item["id"],
                            string_id=item['stringID'],
                            coin_value=item['coinValue'],
                            list_type_id=item['listTypeName'])
@@ -272,7 +271,7 @@ class Loader(object):  # pylint: disable=too-few-public-methods
             try:
                 item = items[0]
                 if self._args.verbose:
-                    print('processing block "{}"'.format(item.display_name))
+                    print('processing block "{}"'.format(item.name()))
                 item.prestige = block['prestige']
                 item.build_xp = block['buildXP']
                 item.mine_xp = block['mineXP']

--- a/blrecipe/clt/recipe.py
+++ b/blrecipe/clt/recipe.py
@@ -2,7 +2,7 @@
 Submodule to handle printing a recipe
 """
 from sys import exit
-from ..storage import Database, Translation, Item, ResourceTag
+from ..storage import Database, Translation, Item, ItemName, ResourceTag
 import re
 import string
 
@@ -62,7 +62,7 @@ def format_recipe_wiki(recipe):
     Format the recipe for WIKI
     """
     wiki_text = '{{RecipeBox\n'
-    wiki_text += '| name = {}\n'.format(recipe.item.display_name)
+    wiki_text += '| name = {}\n'.format(recipe.item.name())
     ingredients = {}
     for ingredient in recipe.ingredients:
         try:
@@ -72,7 +72,7 @@ def format_recipe_wiki(recipe):
 
     icount = 1
     for ingredient in ingredients:
-        wiki_text += "| ingredient{} = {}".format(icount, ingredient.display_name)
+        wiki_text += "| ingredient{} = {}".format(icount, ingredient.name())
         sorted_quant = sorted(ingredients[ingredient].items())
         for quantity in sorted_quant:
             wiki_text += " | ingredient{} {} = {}".format(icount,
@@ -113,11 +113,11 @@ def format_furnace_recipe_wiki(recipe):
     Format the furnace recipe for WIKI
     """
     wiki_text = '{{FurnaceRecipe\n'
-    wiki_text += '| name = {}\n'.format(recipe.item.display_name)
+    wiki_text += '| name = {}\n'.format(recipe.item.name())
     icount = 1
     for ingredient in recipe.ingredients:
         if ingredient.quantity.quantity_id == 0:
-            wiki_text += "| ingredient{} = {}".format(icount, ingredient.display_name)
+            wiki_text += "| ingredient{} = {}".format(icount, ingredient.name())
             wiki_text += "| ingredient{} required = {}\n".format(icount, ingredient.amount)
             icount += 1
 
@@ -163,8 +163,8 @@ def get_item_info(item, tags):
     """
     item_info = {}
 
-    item_info['name'] = item.display_name
-    item_info['class'] = item.subtitle
+    item_info['name'] = item.name()
+    item_info['class'] = item.subtitle()
     item_info['description'] = _do_styling(item.description)
     item_info['prestige'] = item.prestige
     item_info['mine_xp'] = item.mine_xp
@@ -256,34 +256,34 @@ def print_recipe(args):
     database = Database()
     session = database.session()
 
-    item_trans = session.query(Translation).filter_by(value=args.item_name).all()
-    if item_trans is None or len(item_trans) == 0:
+    target_item = session.query(ItemName).filter_by(lang="english", name=args.item_name).first()
+    if target_item is None:
         print('no item matches "{}"'.format(args.item_name))
         exit(1)
-    for itm in item_trans:
-        if args.verbose > 0:
-            print('==> item {} ({})'.format(itm.id, itm.string_id))
-        if itm.string_id.startswith('ITEM_TYPE_'):
-            recipe_boxes = []
-            items = session.query(Item).filter_by(string_id=itm.string_id)
-            if items.count() > 0:
-                item = min(items, key=lambda i: len(i.name))
-                tags = session.query(ResourceTag).filter_by(string_id=item.name).first()
-                item_info = get_item_info(item, tags)
-                final_recipe = None
-                for recipe in item.recipes:
-                    if recipe.machine and recipe.machine.name == 'FURNACE':
-                        recipe_boxes.append(format_furnace_recipe_wiki(recipe))
-                    else:
-                        recipe_boxes.append(format_recipe_wiki(recipe))
-                    item_info['craft_xp'] = recipe.experience
-                    final_recipe = recipe
 
-                if args.print_infobox:
-                    print('<noinclude>{{Version|244}}</noinclude>')
-                    print(_format_infobox_wiki(item_info), end='')
-                for recipe in recipe_boxes:
-                    print(recipe)
-                if args.print_infobox:
-                    print(_format_uses_wiki(item_info), end='')
-                    print_categories_wiki(item_info, final_recipe)
+    if args.verbose > 0:
+        print('==> item {} ({})'.format(target_item.item_id, target_item.name))
+
+    recipe_boxes = []
+    items = session.query(Item).filter_by(id=target_item.item_id)
+    if items.count() > 0:
+        item = min(items, key=lambda i: len(i.name()))
+        tags = session.query(ResourceTag).filter_by(string_id=item.string_id).first()
+        item_info = get_item_info(item, tags)
+        final_recipe = None
+        for recipe in item.recipes:
+            if recipe.machine and recipe.machine.name == 'FURNACE':
+                recipe_boxes.append(format_furnace_recipe_wiki(recipe))
+            else:
+                recipe_boxes.append(format_recipe_wiki(recipe))
+            item_info['craft_xp'] = recipe.experience
+            final_recipe = recipe
+
+        if args.print_infobox:
+            print('<noinclude>{{Version|249}}</noinclude>')
+            print(_format_infobox_wiki(item_info), end='')
+        for recipe in recipe_boxes:
+            print(recipe)
+        if args.print_infobox:
+            print(_format_uses_wiki(item_info), end='')
+            print_categories_wiki(item_info, final_recipe)

--- a/blrecipe/clt/recipe.py
+++ b/blrecipe/clt/recipe.py
@@ -1,10 +1,10 @@
 """
 Submodule to handle printing a recipe
 """
-from sys import exit
-from ..storage import Database, Translation, Item, ItemName, ResourceTag
 import re
 import string
+from sys import exit
+from ..storage import Database, Item, ItemName, ResourceTag
 
 
 def add_parser(subparser):
@@ -140,9 +140,9 @@ def format_furnace_recipe_wiki(recipe):
     wiki_text += '}}'
     return wiki_text
 
-def make_cap(s):
+def make_cap(string):
     """Splits an underscore-separated string into a capitalized string"""
-    return string.capwords(s.lower().replace('_', ' '))
+    return string.capwords(string.lower().replace('_', ' '))
 
 
 def _repl_style(matches):
@@ -151,10 +151,10 @@ def _repl_style(matches):
     else:
         return matches.group(0)
 
-_style_regex = re.compile(r'\$\[STYLE\((?P<target>[^,]*),(?P<style>[^)])\)\]')
+STYLE_REGEX = re.compile(r'\$\[STYLE\((?P<target>[^,]*),(?P<style>[^)])\)\]')
 
 def _do_styling(text):
-    return re.sub(_style_regex, _repl_style, text)
+    return re.sub(STYLE_REGEX, _repl_style, text)
 
 
 def get_item_info(item, tags):

--- a/blrecipe/storage/__init__.py
+++ b/blrecipe/storage/__init__.py
@@ -9,6 +9,7 @@ from .attrconstant import AttrConstant
 from .attrmodifier import AttrModifier
 from .attrarchetype import AttrArchetype
 from .item import Item
+from .language import Language
 from .machine import Machine
 from .quantity import Quantity
 from .recipe import Recipe
@@ -24,6 +25,7 @@ __all__ = ['Database',
            'AttrConstant',
            'AttrModifier',
            'Item',
+           'Language',
            'Machine',
            'Quantity',
            'Recipe',

--- a/blrecipe/storage/__init__.py
+++ b/blrecipe/storage/__init__.py
@@ -16,7 +16,7 @@ from .recipe import Recipe
 from .recipe_ingredient import Ingredient
 from .recipe_quantity import RecipeQuantity
 from .resourcetag import ResourceTag
-from .translation import Translation, i18n
+from .translation import Translation, i18n, ItemName, MetalName
 
 __all__ = ['Database',
            'AttrArchetype',
@@ -25,8 +25,10 @@ __all__ = ['Database',
            'AttrConstant',
            'AttrModifier',
            'Item',
+           'ItemName',
            'Language',
            'Machine',
+           'MetalName',
            'Quantity',
            'Recipe',
            'Ingredient',

--- a/blrecipe/storage/item.py
+++ b/blrecipe/storage/item.py
@@ -6,7 +6,7 @@ from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship, object_session
 from .database import BaseObject
 from .recipe_ingredient import Ingredient
-from .translation import Translation
+from .translation import ItemName, Translation
 
 
 class Item(BaseObject):  # pylint: disable=too-few-public-methods
@@ -15,9 +15,8 @@ class Item(BaseObject):  # pylint: disable=too-few-public-methods
     """
 
     __tablename__ = 'Item'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String(32), unique=True, nullable=False)
-    string_id = Column(String(64), ForeignKey('Translation.string_id'))
+    id = Column(Integer, primary_key=True)
+    string_id = Column(String(64))
     build_xp = Column(Integer, nullable=False, default=0)
     mine_xp = Column(Integer, nullable=False, default=0)
     prestige = Column(Integer, nullable=False, default=0)
@@ -25,24 +24,26 @@ class Item(BaseObject):  # pylint: disable=too-few-public-methods
     list_type_id = Column(String(64), ForeignKey('Translation.string_id'))
     max_stack_size = Column(Integer, nullable=False, default=0)
 
-    translation = relationship('Translation', foreign_keys=[string_id])
     list_type_tr = relationship('Translation', foreign_keys=[list_type_id])
     recipes = relationship('Recipe')
 
-    def __init__(self, name, string_id, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.name = name
-        self.string_id = string_id
 
     def __repr__(self):
-        return '<Item {} ({})>'.format(self.name, self.display_name)
+        return '<Item {} ({})>'.format(self.id, self.name(language='english'))
 
-    @property
-    def display_name(self):
+    def name(self, language='english'):
         """
         Get the (localized) display name of the item.
         """
-        return self.translation.value if self.translation else "[{}]".format(self.string_id)
+        result = object_session(self).query(ItemName)\
+                                     .filter_by(item_id=self.id,
+                                                lang=language)\
+                                     .first()
+        if result is not None:
+            return result.name
+        return '[[unknown]]'
 
     @property
     def description_id(self):
@@ -50,13 +51,6 @@ class Item(BaseObject):  # pylint: disable=too-few-public-methods
         Get the translation key for the item desciption.
         """
         return self.string_id + '_DESCRIPTION'
-
-    @property
-    def subtitle_id(self):
-        """
-        Get the translation key for the item subtitle.
-        """
-        return self.string_id + '_SUBTITLE'
 
     @property
     def description(self):
@@ -70,16 +64,16 @@ class Item(BaseObject):  # pylint: disable=too-few-public-methods
             return result.value
         return ''
 
-    @property
-    def subtitle(self):
+    def subtitle(self, language='english'):
         """
         Get the (localized) subtitle of the item.
         """
-        result = object_session(self).query(Translation)\
-                                     .filter_by(string_id=self.subtitle_id)\
+        result = object_session(self).query(ItemName)\
+                                     .filter_by(item_id=self.id,
+                                                lang=language)\
                                      .first()
         if result is not None:
-            return result.value
+            return result.subtitle
         return ''
 
     @property
@@ -97,6 +91,6 @@ class Item(BaseObject):  # pylint: disable=too-few-public-methods
         result = object_session(self).query(Ingredient)\
                                      .filter_by(item_id=self.id)\
                                      .all()
-        return sorted({use.recipe.item.display_name for use in result})
+        return sorted({use.recipe.item.name() for use in result})
 
 

--- a/blrecipe/storage/language.py
+++ b/blrecipe/storage/language.py
@@ -1,0 +1,24 @@
+"""
+Supported Languages
+
+Boundless supports localization in a number if languages. These languages are
+enumerated in the itemcolorstrings.dat file.
+"""
+
+from sqlalchemy import Column, Integer, String
+from .database import BaseObject
+
+
+class Language(BaseObject):  # pylint: disable=too-few-public-methods
+    """
+    Languages supported for in-gam localization
+    """
+
+    __tablename__ = 'Language'
+    id = Column('id', Integer, primary_key=True, autoincrement=True)
+    name = Column('name', String(32), nullable=False)
+
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = name
+

--- a/blrecipe/storage/recipe.py
+++ b/blrecipe/storage/recipe.py
@@ -41,4 +41,4 @@ class Recipe(BaseObject):  # pylint: disable=too-few-public-methods
         self.handcraftable = handcraftable if handcraftable else 0
 
     def __repr__(self):
-        return '<Recipe "{}">'.format(self.item.display_name)
+        return '<Recipe "{}">'.format(self.item.name(language="english"))

--- a/blrecipe/storage/translation.py
+++ b/blrecipe/storage/translation.py
@@ -13,17 +13,58 @@ class Translation(BaseObject):  # pylint: disable=too-few-public-methods
     __tablename__ = 'Translation'
     __table_args__ = (UniqueConstraint('lang', 'string_id'),)
     id = Column(Integer, primary_key=True, autoincrement=True)
-    lang = Column(String(2), nullable=False)
+    lang = Column(String(32), nullable=False)
     string_id = Column(String(64), nullable=False)
     value = Column(String(255), nullable=False)
 
     def __init__(self, string_id, lang=None, value=None):
-        self.lang = 'en' if lang is None else lang
+        self.lang = 'english' if lang is None else lang
         self.string_id = string_id
         self.value = string_id if value is None else value
+
 
 def i18n(session, string_id):
     """
     Return the internationalized translation of a key string
     """
     return session.query(Translation).filter_by(string_id=string_id).first().value
+
+
+class ItemName(BaseObject):   # pylint: disable=too-few-public-methods
+    """
+    Item name localization table
+
+    The developers switched from using the "strings" translation for items to
+    using the itemcolorstring translation.
+    """
+    __tablename__ = 'ItemName'
+    __table_args__ = (UniqueConstraint('lang', 'item_id'),)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    lang = Column(String(32), nullable=False)
+    item_id = Column(Integer, nullable=False)
+    name = Column(String(255), nullable=False)
+    subtitle = Column(String(255))
+
+    def __init__(self, item_id, lang=None, name=None, subtitle=None):
+        self.lang = 'english' if lang is None else lang
+        self.item_id = item_id
+        self.name = "[item {}]".format(item_id) if name is None else name
+        self.subtitle = subtitle
+
+
+class MetalName(BaseObject):   # pylint: disable=too-few-public-methods
+    """
+    Metal name localization table
+    """
+    __tablename__ = 'MetalName'
+    __table_args__ = (UniqueConstraint('lang', 'metal_id'),)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    lang = Column(String(32), nullable=False)
+    metal_id = Column(Integer, nullable=False)
+    name = Column(String(255), nullable=False)
+
+    def __init__(self, metal_id, lang=None, name=None):
+        self.lang = 'english' if lang is None else lang
+        self.metal_id = metal_id
+        self.name = "[metal {}]".format(metal_id) if name is None else name
+

--- a/tests/unit/storage/test_translation.py
+++ b/tests/unit/storage/test_translation.py
@@ -35,7 +35,7 @@ class TestItemName(TestCase):
         Verify basic constructor
         """
         test_item_id = 1024
-        test_language='inuktitut'
+        test_language = 'inuktitut'
         test_name = 'Groundhog'
 
         item_name = ItemName(item_id=test_item_id, lang=test_language, name=test_name)

--- a/tests/unit/storage/test_translation.py
+++ b/tests/unit/storage/test_translation.py
@@ -1,8 +1,8 @@
 """
-Test the Translationmodel
+Test the Translation module
 """
 from unittest import TestCase
-from blrecipe.storage import Translation
+from blrecipe.storage import Translation, ItemName
 
 
 class TestTranslation(TestCase):
@@ -16,9 +16,30 @@ class TestTranslation(TestCase):
         """
         test_key = 'WOODCHUCK'
         test_value = 'Groundhog'
+        test_language = 'english'
 
         translation = Translation(string_id=test_key, value=test_value)
 
         self.assertEqual(translation.string_id, test_key)
         self.assertEqual(translation.value, test_value)
-        self.assertEqual(translation.lang, 'en')
+        self.assertEqual(translation.lang, test_language)
+
+
+class TestItemName(TestCase):
+    """
+    Validate the ItemNamen table
+    """
+
+    def test_ctor(self):
+        """
+        Verify basic constructor
+        """
+        test_item_id = 1024
+        test_language='inuktitut'
+        test_name = 'Groundhog'
+
+        item_name = ItemName(item_id=test_item_id, lang=test_language, name=test_name)
+
+        self.assertEqual(item_name.item_id, test_item_id)
+        self.assertEqual(item_name.name, test_name)
+        self.assertEqual(item_name.lang, test_language)


### PR DESCRIPTION
Upstream has switched to using a file called 'itemcolorstrings.dat' to contain all of the item name (among other things) translations in an encoded format. This change switches to using that instead of the various archetype/strings files.